### PR TITLE
Add new params for UseTLS and Join

### DIFF
--- a/cmd/out/out.go
+++ b/cmd/out/out.go
@@ -21,6 +21,8 @@ type Source struct {
 	Channel  string `json:"channel"`
 	User     string `json:"user"`
 	Password string `json:"password"`
+   UseTLS   bool   `json:"usetls"`
+   Join     bool   `json:"join"`
 }
 
 type Params struct {
@@ -96,6 +98,8 @@ func BuildResponse(request *Request, message string) *Response {
 	response.Metadata = append(response.Metadata, Metadatum{"host", connString(request)})
 	response.Metadata = append(response.Metadata, Metadatum{"channel", request.Source.Channel})
 	response.Metadata = append(response.Metadata, Metadatum{"user", request.Source.User})
+	response.Metadata = append(response.Metadata, Metadatum{"usetls", fmt.Sprintf("%v", request.Source.UseTLS)})
+	response.Metadata = append(response.Metadata, Metadatum{"join", fmt.Sprintf("%v", request.Source.Join)})
 	response.Metadata = append(response.Metadata, Metadatum{"message", message})
 	response.Metadata = append(response.Metadata, Metadatum{"dry_run", fmt.Sprintf("%v", request.Params.DryRun)})
 	response.Version.Ref = "none"
@@ -105,12 +109,18 @@ func BuildResponse(request *Request, message string) *Response {
 func SendMessage(request *Request, message string) error {
 	conn := irc.New(request.Source.User, request.Source.User)
 
-	conn.UseTLS = true
+	conn.UseTLS = request.Source.UseTLS
 	conn.Log = log.New(ioutil.Discard, "", 0) // be completely silent
 	conn.Password = request.Source.Password
 
 	conn.AddCallback("001", func(*irc.Event) {
+      if request.Source.Join {
+         conn.Join(request.Source.Channel)
+      }
 		conn.Privmsg(request.Source.Channel, message)
+      if request.Source.Join {
+         conn.Part(request.Source.Channel)
+      }
 		conn.Quit()
 	})
 

--- a/cmd/out/out_test.go
+++ b/cmd/out/out_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Out", func() {
 		Context("when valid", func() {
 			Describe("source", func() {
 				It("returns correct values", func() {
-					request, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "port": 7070, "channel": "#random", "user": "randobot1337", "password": "secretsecret"}, "params": {"message": "foo"}}`))
+               request, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "port": 7070, "channel": "#random", "user": "randobot1337", "password": "secretsecret", "usetls": true, "join": false}, "params": {"message": "foo"}}`))
 					Expect(error).To(BeNil())
 					Expect(request.Source).To(MatchAllFields(Fields{
 						"Server":   Equal("chat.freenode.net"),
@@ -26,6 +26,8 @@ var _ = Describe("Out", func() {
 						"Channel":  Equal("#random"),
 						"User":     Equal("randobot1337"),
 						"Password": Equal("secretsecret"),
+                  "UseTLS":   Equal(true),
+                  "Join":     Equal(false),
 					}))
 				})
 			})
@@ -33,7 +35,7 @@ var _ = Describe("Out", func() {
 			Describe("params", func() {
 				Describe("`message`", func() {
 					It("returns correct value", func() {
-						request, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "port": 7070, "channel": "#random", "user": "randobot1337", "password": "secretsecret"}, "params": {"message": "foo $BUILD_ID"}}`))
+						request, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "port": 7070, "channel": "#random", "user": "randobot1337", "password": "secretsecret", "usetls": true, "join": false}, "params": {"message": "foo $BUILD_ID"}}`))
 						Expect(error).To(BeNil())
 						Expect(request.Params).To(MatchFields(IgnoreExtras, Fields{
 							"Message": Equal("foo $BUILD_ID"),
@@ -43,19 +45,19 @@ var _ = Describe("Out", func() {
 
 				Describe("`dry_run`", func() {
 					It("defaults to false", func() {
-						request, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "port": 7070, "channel": "#random", "user": "randobot1337", "password": "secretsecret"}, "params": {"message": "foo $BUILD_ID"}}`))
+						request, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "port": 7070, "channel": "#random", "user": "randobot1337", "password": "secretsecret", "usetls": true, "join": false}, "params": {"message": "foo $BUILD_ID"}}`))
 						Expect(error).To(BeNil())
 						Expect(request.Params).To(MatchFields(IgnoreExtras, Fields{"DryRun": BeFalse()}))
 					})
 
 					It("is settable to true", func() {
-						request, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "port": 7070, "channel": "#random", "user": "randobot1337", "password": "secretsecret"}, "params": {"message": "foo $BUILD_ID", "dry_run": true}}`))
+						request, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "port": 7070, "channel": "#random", "user": "randobot1337", "password": "secretsecret", "usetls": true, "join": false}, "params": {"message": "foo $BUILD_ID", "dry_run": true}}`))
 						Expect(error).To(BeNil())
 						Expect(request.Params).To(MatchFields(IgnoreExtras, Fields{"DryRun": BeTrue()}))
 					})
 
 					It("is settable to false", func() {
-						request, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "port": 7070, "channel": "#random", "user": "randobot1337", "password": "secretsecret"}, "params": {"message": "foo $BUILD_ID", "dry_run": false}}`))
+						request, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "port": 7070, "channel": "#random", "user": "randobot1337", "password": "secretsecret", "usetls": true, "join": false}, "params": {"message": "foo $BUILD_ID", "dry_run": false}}`))
 						Expect(error).To(BeNil())
 						Expect(request.Params).To(MatchFields(IgnoreExtras, Fields{"DryRun": BeFalse()}))
 					})
@@ -65,34 +67,34 @@ var _ = Describe("Out", func() {
 
 		Describe("required source property", func() {
 			It("`server`", func() {
-				_, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"port": 7070, "channel": "#random", "user": "randobot1337", "password": "secretsecret"}}`))
+				_, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"port": 7070, "channel": "#random", "user": "randobot1337", "password": "secretsecret", "usetls": true, "join": false}}`))
 				Expect(error.Error()).To(MatchRegexp(`No server was provided`))
 			})
 
 			It("`port`", func() {
-				_, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "channel": "#random", "user": "randobot1337", "password": "secretsecret"}}`))
+				_, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "channel": "#random", "user": "randobot1337", "password": "secretsecret", "usetls": true, "join": false}}`))
 				Expect(error.Error()).To(MatchRegexp(`No port was provided`))
 			})
 
 			It("`channel`", func() {
-				_, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "port": 7070, "user": "randobot1337", "password": "secretsecret"}}`))
+				_, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "port": 7070, "user": "randobot1337", "password": "secretsecret", "usetls": true, "join": false}}`))
 				Expect(error.Error()).To(MatchRegexp(`No channel was provided`))
 			})
 
 			It("`user`", func() {
-				_, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "port": 7070, "channel": "#random", "password": "secretsecret"}}`))
+				_, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "port": 7070, "channel": "#random", "password": "secretsecret", "usetls": true, "join": false}}`))
 				Expect(error.Error()).To(MatchRegexp(`No user was provided`))
 			})
 
 			It("`password`", func() {
-				_, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "port": 7070, "channel": "#random", "user": "randobot1337"}}`))
+				_, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "port": 7070, "channel": "#random", "user": "randobot1337", "usetls": true, "join": false}}`))
 				Expect(error.Error()).To(MatchRegexp(`No password was provided`))
 			})
 		})
 
 		Describe("required params property", func() {
 			It("`message`", func() {
-				_, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "port": 7070, "channel": "#random", "user": "randobot1337", "password": "secretsecret"}}`))
+				_, error := ParseAndCheckRequest(bytes.NewBufferString(`{"source": {"server": "chat.freenode.net", "port": 7070, "channel": "#random", "user": "randobot1337", "password": "secretsecret", "usetls": true, "join": false}}`))
 				Expect(error.Error()).To(MatchRegexp(`No message was provided`))
 			})
 		})
@@ -109,6 +111,8 @@ var _ = Describe("Out", func() {
 					Channel:  "#random",
 					User:     "randobot1337",
 					Password: "secretsecret",
+               UseTLS:   true,
+               Join:     false,
 				},
 				Params: Params{DryRun: true},
 			}
@@ -146,6 +150,8 @@ var _ = Describe("Out", func() {
 					Channel:  "#random",
 					User:     "randobot1337",
 					Password: "secretsecret",
+               UseTLS:   true,
+               Join:     false,
 				},
 				Params: Params{DryRun: true},
 			}
@@ -171,6 +177,8 @@ var _ = Describe("Out", func() {
 				Metadatum{"host", "chat.freenode.net:7070"},
 				Metadatum{"channel", "#random"},
 				Metadatum{"user", "randobot1337"},
+				Metadatum{"usetls", "true"},
+				Metadatum{"join", "false"},
 				Metadatum{"message", "this is a message"},
 				Metadatum{"dry_run", "true"},
 			}))

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -14,7 +14,9 @@ cat > $tempdir/input.json <<EOF
     "port": 7070,
     "channel": "#random",
     "user": "randobot1337",
-    "password": "secretsecret"
+    "password": "secretsecret",
+    "usetls": true,
+    "join": false
   },
   "params": {
     "message": "This is from \${BUILD_ID}, a.k.a. \${BUILD_NAME}, see \${BUILD_URL}",
@@ -40,6 +42,14 @@ cat > $tempdir/expected.json <<EOF
     {
       "name": "user",
       "value": "randobot1337"
+    },
+    {
+      "name": "usetls",
+      "value": "true"
+    },
+    {
+      "name": "join",
+      "value": "false"
     },
     {
       "name": "message",


### PR DESCRIPTION
Added 2 new params:
1) UseTLS so this can be disabled when connecting to an internal IRC server not using TLS
2) Join which will first Join the channel before posting the message, then leave it. Seems to be required on ngircd.