### PR TITLE
Pin Alpine version and force clean build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine AS builder
+FROM golang:alpine3.11 AS builder
 RUN apk --no-cache add bash ca-certificates git make
 
 # related to https://github.com/golang/go/issues/26988
@@ -8,7 +8,7 @@ RUN go get github.com/onsi/ginkgo/ginkgo
 RUN go get github.com/onsi/gomega/...
 
 COPY . /root/irc-notification-resource
-RUN cd /root/irc-notification-resource && make test
+RUN cd /root/irc-notification-resource && make clean && make test
 
-FROM alpine:edge AS resource
+FROM alpine:3.11 AS resource
 COPY --from=builder /root/irc-notification-resource/artifacts /opt/resource


### PR DESCRIPTION
There are some OCI image build applications like `buildah` and `podman` that do not respect `.dockerignore`. If the build context is initialized with a locally built `./artifacts` folder, there might be a `libc` / `musl` mismatch, and the integration tests will fail with `file not found`.

This commit ensures the build context is cleaned on every image build, ensuring the binaries in the `artifacts` folder are rebuilt, and built against the right dynamic link. The commit also pins the Alpine image version, and thus pins the `musl` version that to be shared across the build and runtime  images.